### PR TITLE
Log passed in ptype rather than _ptype member in sendPacket

### DIFF
--- a/src/main/java/com/phono/srtplight/RTPProtocolImpl.java
+++ b/src/main/java/com/phono/srtplight/RTPProtocolImpl.java
@@ -218,10 +218,10 @@ public class RTPProtocolImpl extends BitUtils implements RTPProtocolFace {
             appendAuth(payload);
             sendToNetwork(payload);
 
-            Log.verb("sending RTP " + _ptype + " packet length " + payload.length + "seq =" + (int) seqno + " csrc=" + _csrcid + " stamp=" + stamp);
+            Log.verb("sending RTP " + ptype + " packet length " + payload.length + "seq =" + (int) seqno + " csrc=" + _csrcid + " stamp=" + stamp);
         } catch (IOException ex) {
             _lastx = ex;
-            Log.error("Not sending RTP " + _ptype + "ex = " + ex.getMessage());
+            Log.error("Not sending RTP " + ptype + "ex = " + ex.getMessage());
             throw ex;
         }
 


### PR DESCRIPTION
Hi,

just a small oversight I noticed while trying to figure out what the purpose of `_ptype` was :smile:

Thanks for this concise library!

Cheers
Moritz