### PR TITLE
Fix SRTP double-encryption on send

### DIFF
--- a/src/main/java/com/phono/srtplight/SRTPProtocolImpl.java
+++ b/src/main/java/com/phono/srtplight/SRTPProtocolImpl.java
@@ -377,21 +377,6 @@ public class SRTPProtocolImpl extends RTPProtocolImpl {
 
     }
 
-    @Override
-    public void sendPacket(byte[] data, long stamp, int ptype, boolean marker) throws SocketException,
-            IOException {
-        try {
-            if (_doCrypt) {
-                _scOut.deriveKeys(stamp);
-                encrypt(data, (int) _csrcid, _seqno);
-            }
-            super.sendPacket(data, stamp, ptype, marker);
-        } catch (GeneralSecurityException ex) {
-            Log.error("problem encrypting packet" + ex.getMessage());
-            ex.printStackTrace();
-        }
-    }
-
     static ByteBuffer getPepper(int ssrc, long idx) {
         //(SSRC * 2^64) XOR (i * 2^16)
         ByteBuffer pepper = ByteBuffer.allocate(16);


### PR DESCRIPTION
It turns out that the SRTP send implementation was redundantly encrypting payloads when using the 4-ary `sendPacket` method. The override for that method in `SRTPProtocolImpl` would encrypt the payload data and then proceed to invoke its parent's implementation. That one in turn would invoke the 5-ary `sendPacket` method which is also overriden in `SRTPProtocolImpl`. That override would encrypt the payload a second time, resulting in garbled data on the receiver's end.

Fixed by removing the 4-ary override from `SRTPProtocolImpl`.

Confirmed to work by testing against a real-world VoIP provider's SRTP implementation. However, I was unable to run the `rtpw`-based manual tests which I assume either need to be adjusted or must have been failing before?